### PR TITLE
Allow compile options for ss-jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Add `ss-jade` to your application's `package.json` file and then add this line t
 ss.client.formatters.add(require('ss-jade'));
 ```
 
+To add options to the compile settings in ss-jade, require the file first, call the ```addCompileOptions``` function, and then add the ss-jade object to the SocketStream client formatters, like so:
+
+``` javascript
+var ssJade = require('ss-jade');
+ssJade.addCompileOptions({ pretty: true });
+ss.client.formatters.add(ssJade);
+```
 
 ### Passing local variables
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Allows you to use [Jade](http://jade-lang.com) files (.jade) in your SocketStream project.
 
-
 ### Instructions
 
 Add `ss-jade` to your application's `package.json` file and then add this line to app.js:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "jade": "0.27.x"
+    "jade": "0.28.x"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "jade": "0.28.x"
+    "jade": ">= 0.34.x"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "jade": ">= 0.34.x"
+    "jade": ">= 1.7.0"
   },
   "devDependencies": {}
 }

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,7 +1,8 @@
 // Jade 'HTML' wrapper for SocketStream 0.3
 
 var fs = require('fs'),
-    jade = require('jade');
+    jade = require('jade'),
+    _transferOptions;
 
 exports.init = function(root, config) {
 
@@ -19,7 +20,7 @@ exports.init = function(root, config) {
 
     compile: function(path, options, cb) {
 
-      var locals = {};
+      var i, compileOptions = {filename: path}, locals = {};
 
       // Merge any locals passed to config.locals
       if (config.locals && typeof(config.locals) === 'object')
@@ -28,11 +29,21 @@ exports.init = function(root, config) {
       // If passing optional headers for main view HTML
       if (options && options.headers) locals['SocketStream'] = options.headers;
 
+      if(typeof _transferOptions === 'object') {
+        for (var attrname in _transferOptions) { compileOptions[attrname] = _transferOptions[attrname]; }
+      }
+
       var input = fs.readFileSync(path, 'utf8');
-      var parser = jade.compile(input, {filename: path});
+      var parser = jade.compile(input, compileOptions);
       var output = parser(locals);
 
       cb(output);
     }
   };
+};
+
+exports.addCompileOptions = function(options) {
+  if(typeof options === 'object') {
+    _transferOptions = options;
+  }
 };


### PR DESCRIPTION
Not sure this is the best way to do it, but I often like to see "pretty html" when I'm doing development, and since I started a new project using Jade, I threw this together and included it in my project like such:

```
"ss-jade": "https://github.com/americanyak/ss-jade/tarball/master",
```

To add options to the compile settings in ss-jade, require the file first, call the "addCompileOptions" function, and then add the ssJade object to the SocketStream client formatters, like so:

```
var ssJade = require('ss-jade');
ssJade.addCompileOptions({ pretty: true });
ss.client.formatters.add(ssJade);
```

You might want to pull this into ss-jade a different way, but I needed to be able to add to the options, and this was my method. :)
