### PR TITLE
make ss-jade accept locals from serveClient

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -19,7 +19,7 @@ exports.init = function(root, config) {
 
     compile: function(path, options, cb) {
 
-      var locals = {};
+      var locals = (options && options.locals) ? options.locals : {};
 
       // Merge any locals passed to config.locals
       if (config.locals && typeof(config.locals) === 'object')


### PR DESCRIPTION
This make ss-jade accept parameter from res.serveClient(). It depends on the pull:
https://github.com/socketstream/socketstream/pull/341

```
res.serveClient('main', {
  title : 'main',
  version : '1.0'
});
```
